### PR TITLE
Rename GATE_TYPE var to SERVICE_TYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ $> make test
 ### Services
 The gate service can be configured via the following environment variables:
 
-- LISTEN_ADDR:        `string`  The server address gates binds to.
-- GATE_TY: `string`  A gate to emulate. [choices: and, not, or, xor]
-- OUTPUT_TY:  `url.URL` A an outputer to send a computed output to. [choices: stdout, http]
-- OUTPUT_ADDRS:  `[]url.URL` An optional list of address for the http outputter to send a computed output to.
+- LISTEN_ADDR:		`string`	The server address gates binds to.
+- SERVICE_TY:		`string`	A service or gate to emulate. [choices: and, not, or, xor]
+- OUTPUT_TY:		`url.URL`	A an outputer to send a computed output to. [choices: stdout, http]
+- OUTPUT_ADDRS:		`[]url.URL`	An optional list of address for the http outputter to send a computed output to.
 
 ## Usage
 ### Example

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     build: .
     environment:
       LISTEN_ADDR: "0.0.0.0:8080"
-      GATE_TYPE: not
+      SERVICE_TYPE: not
       OUTPUT_TYPE: http
       OUTPUT_ADDRS: 'http://and_gate:8080/input/a'
     healthcheck:
@@ -21,7 +21,7 @@ services:
     build: .
     environment:
       LISTEN_ADDR: "0.0.0.0:8080"
-      GATE_TYPE: or
+      SERVICE_TYPE: or
       OUTPUT_TYPE: http
       OUTPUT_ADDRS: 'http://and_gate:8080/input/b'
     healthcheck:
@@ -38,7 +38,7 @@ services:
     build: .
     environment:
       LISTEN_ADDR: "0.0.0.0:80"
-      GATE_TYPE: and
+      SERVICE_TYPE: and
       OUTPUT_TYPE: stdout
     healthcheck:
       test:
@@ -54,7 +54,7 @@ services:
     build: .
     environment:
       LISTEN_ADDR: "0.0.0.0:80"
-      GATE_TYPE: xor
+      SERVICE_TYPE: xor
       OUTPUT_TYPE: stdout
     healthcheck:
       test:

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 func instantiateGateFromConfig(c *config.Config) gate.Gate {
 	var g gate.Gate = nil
 
-	switch c.GateTy {
+	switch c.ServiceTy {
 	case "not":
 		g = &gate.Not{}
 	case "and":
@@ -145,7 +145,7 @@ func main() {
 		inboundMsgs, stateQuitChan := startStateManagerService(gg)
 
 		log.Printf("Starting server on %s\n", c.ListenAddr)
-		log.Printf("Configured as %s gate\n", c.GateTy)
+		log.Printf("Configured as %s gate\n", c.ServiceTy)
 
 		httpServerExitDone := &sync.WaitGroup{}
 		httpServerExitDone.Add(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,7 @@ func (e *ErrUndefinedConfig) Error() string {
 // global level.
 type Config struct {
 	ListenAddr  string    `env:"ListenAddr" envDefault:"0.0.0.0:8080"`
-	GateTy      string    `env:"GATE_TYPE"`
+	ServiceTy   string    `env:"SERVICE_TYPE"`
 	OutputTy    string    `env:"OUTPUT_TYPE" envDefault:"stdout"`
 	OutputAddrs []url.URL `env:"OUTPUT_ADDRS" envSeparator:" " envDefault:""`
 }
@@ -52,7 +52,7 @@ func New() (Config, error) {
 	}
 
 	valid := false
-	switch c.GateTy {
+	switch c.ServiceTy {
 	case "and":
 		valid = true
 	case "or":
@@ -67,7 +67,7 @@ func New() (Config, error) {
 
 	if !valid {
 		return c, &ErrInvalidGateType{
-			gate: c.GateTy,
+			gate: c.ServiceTy,
 		}
 	}
 


### PR DESCRIPTION
# Introduction
Small refactor to rename the `GATE_TYPE` env var to `SERVICE_TYPE` to make room for non-gate services like, signals (i.e. clock), external input, etc...
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
