### PR TITLE
Fix branch trigger on publish image job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branch:
+    branches:
       - main
     tags:
       - '*'


### PR DESCRIPTION
# Introduction
This is a small bugfix to correct the `main` branch trigger from `branch` to `branches` on the publish image job.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
