### PR TITLE
Remove job dependency in publish job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,6 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    needs: get_version
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
# Introduction
An additional bugfix to fix the publish jobs dependencies on non-existent `get_version` job.
# Linked Issues

# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
